### PR TITLE
[Fix] Throw exception if record is not found

### DIFF
--- a/src/PotatoModel.php
+++ b/src/PotatoModel.php
@@ -164,7 +164,7 @@ class PotatoModel extends DatabaseConnection
                 return new static();
             }
 
-            return false;
+            throw new PDOException("No record found with that ID.");
         } catch (PDOException $e) {
             throw new PDOException($e->getMessage());
         }


### PR DESCRIPTION
Throw an exception when you find a record that does not exist as opposed to returning false